### PR TITLE
Handle a non-string __version__

### DIFF
--- a/version_information.py
+++ b/version_information.py
@@ -94,7 +94,7 @@ class VersionInformation(Magics):
         for module in modules:
             if len(module) > 0:
                 try:
-                    code = ("import %s; version=%s.__version__" %
+                    code = ("import %s; version=str(%s.__version__)" %
                             (module, module))
                     ns_g = ns_l = {}
                     exec(compile(code, "<string>", "exec"), ns_g, ns_l)


### PR DESCRIPTION
Although `__version__` is usually a string, there is no standard requiring this. When this extension is used with a package that has a non-string `__version__`, the HTML table is no longer displayed, and the following warning is given (this was for a float):

```
.../python2.7/site-packages/IPython/core/formatters.py:239: FormatterWarning: Exception in text/html formatter: 'float' object has no attribute 'replace'
  FormatterWarning,
.../python2.7/site-packages/IPython/core/formatters.py:239: FormatterWarning: Exception in text/latex formatter: 'float' object is not iterable
  FormatterWarning,
```

Adding in a `str()` call should fix this.