### PR TITLE
Fix for https://github.com/jrjohansson/version_information/issues/15

### DIFF
--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -48,6 +48,7 @@ Usage
 
 """
 import cgi
+import html
 import json
 import sys
 import time
@@ -122,20 +123,20 @@ class VersionInformation(Magics):
 
     def _repr_html_(self):
 
-        html = "<table>"
-        html += "<tr><th>Software</th><th>Version</th></tr>"
+        html_str = "<table>"
+        html_str += "<tr><th>Software</th><th>Version</th></tr>"
         for name, version in self.packages:
-            _version = cgi.escape(version)
-            html += "<tr><td>%s</td><td>%s</td></tr>" % (name, _version)
+            _version = html.escape(version)
+            html_str += "<tr><td>%s</td><td>%s</td></tr>" % (name, _version)
 
         try:
-            html += "<tr><td colspan='2'>%s</td></tr>" % time.strftime(timefmt)
+            html_str += "<tr><td colspan='2'>%s</td></tr>" % time.strftime(timefmt)
         except:
-            html += "<tr><td colspan='2'>%s</td></tr>" % \
+            html_str += "<tr><td colspan='2'>%s</td></tr>" % \
                 time.strftime(timefmt).decode(_date_format_encoding())
-        html += "</table>"
+        html_str += "</table>"
 
-        return html
+        return html_str
 
     @staticmethod
     def _latex_escape(str_):

--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -47,7 +47,6 @@ Usage
    (the ``version`` field from ``setup.py``).
 
 """
-import cgi
 import html
 import json
 import sys


### PR DESCRIPTION
This pull request replaces `cgi.escape()` with `html.escape()` for Python 3.8+ compatibility.