### PR TITLE
add version information for non python packages

### DIFF
--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -74,12 +74,11 @@ class VersionInformation(Magics):
     
     def get_non_python_package_version(self, package):
         try:
-            result=subprocess.getoutput(package  + " --version")
+            result = subprocess.getoutput(package  + " --version")
         except Exception as e:
             result = "Package not found " + str(e)
         self.packages.append((package, result))
 
-        return self
         
     def get_module_version(self, module):
         try:
@@ -97,7 +96,6 @@ class VersionInformation(Magics):
             except Exception as e:
                 self.packages.append((module, str(e)))
 
-        return self
 
 
     @line_magic

--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -78,7 +78,27 @@ class VersionInformation(Magics):
         except:
             result = "not found"
         self.packages.append((package, result))
+
+        return self
         
+    def get_module_version(self, module):
+        try:
+            code = ("import %s; version=str(%s.__version__)" %
+                    (module, module))
+            ns_g = ns_l = {}
+            exec(compile(code, "<string>", "exec"), ns_g, ns_l)
+            self.packages.append((module, ns_l["version"]))
+        except Exception as e:
+            try:
+                if pkg_resources is None:
+                    raise
+                version = pkg_resources.require(module)[0].version
+                self.packages.append((module, version))
+            except Exception as e:
+                self.packages.append((module, str(e)))
+
+        return self
+
 
     @line_magic
     def version_information(self, line=''):
@@ -102,21 +122,7 @@ class VersionInformation(Magics):
 
         for module in modules:
             if len(module) > 0:
-                try:
-                    code = ("import %s; version=str(%s.__version__)" %
-                            (module, module))
-                    ns_g = ns_l = {}
-                    exec(compile(code, "<string>", "exec"), ns_g, ns_l)
-                    self.packages.append((module, ns_l["version"]))
-                except Exception as e:
-                    try:
-                        if pkg_resources is None:
-                            raise
-                        version = pkg_resources.require(module)[0].version
-                        self.packages.append((module, version))
-                    except Exception as e:
-                        self.packages.append((module, str(e)))
-
+                
         return self
 
     def _repr_json_(self):

--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -122,6 +122,10 @@ class VersionInformation(Magics):
 
         for module in modules:
             if len(module) > 0:
+                if(module.startswith('!')):
+                    self.get_non_python_package_version(module[1:])
+                else:
+                    self.get_module_version(module)
                 
         return self
 

--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -74,9 +74,9 @@ class VersionInformation(Magics):
     
     def get_non_python_package_version(self, package):
         try:
-            result=subprocess.getoutput(string  + " --version")
-        except:
-            result = "not found"
+            result=subprocess.getoutput(package  + " --version")
+        except Exception as e:
+            result = "Package not found " + str(e)
         self.packages.append((package, result))
 
         return self

--- a/version_information/version_information.py
+++ b/version_information/version_information.py
@@ -49,6 +49,7 @@ Usage
 """
 import html
 import json
+import subprocess
 import sys
 import time
 import locale
@@ -70,6 +71,14 @@ def _date_format_encoding():
 
 @magics_class
 class VersionInformation(Magics):
+    
+    def get_non_python_package_version(self, package):
+        try:
+            result=subprocess.getoutput(string  + " --version")
+        except:
+            result = "not found"
+        self.packages.append((package, result))
+        
 
     @line_magic
     def version_information(self, line=''):


### PR DESCRIPTION
This PR tries to fix the issue mentioned in #20.
The PR assumes that the non python package ( say `octopus` ) takes a parameter `--version` to return the version information, which is true for a good number of such packages.
The new usage for `version_information` would be : 
```python
%version_information pandas, postopus, !octopus
```
```bash

In [1]: %load_ext version_information

In [2]: %version_information pandas, postopus, !octopus
Out[2]: 
Software versions
Python 3.8.13 64bit [GCC 10.3.0]
IPython 8.4.0
OS Linux 5.19.0 0.deb11.2 amd64 x86_64 with glibc2.10
pandas 1.5.1
postopus 0.0.1.post1.dev986+gbc1e29c
octopus octopus 12.0 (git commit )
Thu Nov 10 13:58:06 2022 CET
```